### PR TITLE
【修复】chunk 模式获取 chunk_sz = 0 时，webclient_recv 函数返回错误问题

### DIFF
--- a/src/webclient.c
+++ b/src/webclient.c
@@ -1126,6 +1126,7 @@ static int webclient_next_chunk(struct webclient_session *session)
         /* end of chunks */
         closesocket(session->socket);
         session->socket = -1;
+        session->chunk_sz = -1;
     }
 
     return session->chunk_sz;
@@ -1149,6 +1150,12 @@ int webclient_read(struct webclient_session *session, unsigned char *buffer, siz
     int left;
 
     RT_ASSERT(session);
+
+    /* get next chunk size is zero, client is already closed, return zero */
+    if (session->chunk_sz < 0)
+    {
+        return 0;
+    }
 
     if (session->socket < 0)
     {


### PR DESCRIPTION
Signed-off-by: chenyong <1521761801@qq.com>