### PR TITLE
修复webclient GET request failed情况下内存双重释放问题

### DIFF
--- a/src/webclient.c
+++ b/src/webclient.c
@@ -1398,11 +1398,13 @@ static int webclient_clean(struct webclient_session *session)
     if (session->host)
     {
         web_free(session->host);
+        session->host = RT_NULL;
     }
 
     if (session->req_url)
     {
         web_free(session->req_url);
+        session->req_url = RT_NULL;
     }
 
     session->content_length = -1;


### PR DESCRIPTION
webclient GET request failed情况下会对已经释放过的内存session->host和session->req_url再次释放导致断言，通过释放后把指针赋空，修复内存双重释放。