### PR TITLE
[FIX] fix potential webclient_resolve_address crash when getaddrinfo …

### DIFF
--- a/src/webclient.c
+++ b/src/webclient.c
@@ -178,6 +178,8 @@ static int webclient_resolve_address(struct webclient_session *session, struct a
     RT_ASSERT(res);
     RT_ASSERT(request);
 
+    /* make sure *res = NULL before getaddrinfo */
+    *res = RT_NULL;
     url_len = rt_strlen(url);
 
     /* strip protocol(http or https) */


### PR DESCRIPTION
potential crash in freeaddrinfo when getaddrinfo failed but user parameter ` struct addrinfo **res` not be initialized like `*res = RT_NULL`