### PR TITLE
[HUST CSE]Fixed an error where parameters could not be assigned

### DIFF
--- a/samples/webclient_get_sample.c
+++ b/samples/webclient_get_sample.c
@@ -101,6 +101,7 @@ __exit:
     if (session)
     {
         webclient_close(session);
+        session = RT_NULL;
     }
 
     if (buffer)

--- a/samples/webclient_post_sample.c
+++ b/samples/webclient_post_sample.c
@@ -77,6 +77,7 @@ __exit:
     if (session)
     {
         webclient_close(session);
+        session = RT_NULL;
     }
 
     if (buffer)

--- a/samples/webclient_shard_download_sample.c
+++ b/samples/webclient_shard_download_sample.c
@@ -132,6 +132,7 @@ __exit:
     if (session)
     {
         webclient_close(session);
+        session = RT_NULL;
     }
 
     return result;

--- a/src/webclient_file.c
+++ b/src/webclient_file.c
@@ -132,6 +132,7 @@ __exit:
     if (session != RT_NULL)
     {
         webclient_close(session);
+        session = RT_NULL;
     }
 
     if (ptr != RT_NULL)
@@ -287,6 +288,7 @@ __exit:
     if (session != RT_NULL)
     {
         webclient_close(session);
+        session = RT_NULL;
     }
 
     if (buffer != RT_NULL)


### PR DESCRIPTION
在：https://github.com/RT-Thread-packages/webclient/blob/master/src/webclient.c#L1863-L1864 这里，
![image](https://user-images.githubusercontent.com/130630592/235281512-10c7b399-c360-4226-9869-c662fe4547bd.png)

在使用完`webclient_close`函数后，手动使用`session = RT_NULL;`将session赋值成NULL;
但是在其它地方，如https://github.com/RT-Thread-packages/webclient/blob/master/samples/webclient_get_sample.c#L103 
 中，在使用webclient_close函数后，并未使用相同的处理方式，从而可能导致free掉的指针再次被使用。
在每次调用`webclient_close`函数后，手动使用`session = RT_NULL;`将session赋值成NULL，避免这一问题的发生。